### PR TITLE
Added special error for single quotes

### DIFF
--- a/manifest-parser.js
+++ b/manifest-parser.js
@@ -229,7 +229,11 @@ var ManifestParser = (function() {
     try {
       _json_input = JSON.parse(string);
     } catch (e) {
-      _logs.push("File isn't valid JSON: " + e);
+      if (e.message === "Unexpected token '") {
+        _logs.push("File isn't valid JSON: Double quotes are considered valid JSON, single quotes aren't. Please use double quotes." + e.stack);
+      } else {
+        _logs.push("File isn't valid JSON: " + e);
+      }
       _success = false;
       return;
     }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "chai": "latest",
     "mocha": "latest"
   }
 }

--- a/tests/manifest-parser-tests.js
+++ b/tests/manifest-parser-tests.js
@@ -1,5 +1,5 @@
 var ManifestParser = require('../manifest-parser.js');
-var assert = require('assert');
+var assert = require('chai').assert;
 
 describe('Manifest Parser', function() {
   it('should not parse empty string input', function() {
@@ -44,6 +44,13 @@ describe('Manifest Parser', function() {
     assert.equal(null, ManifestParser.manifest().orientation);
     assert.equal(null, ManifestParser.manifest().theme_color);
     assert.equal(null, ManifestParser.manifest().background_color);
+  });
+
+  it('fails on single quotes', function() {
+    ManifestParser.parse('{\'foo\': \'bar\'}');
+    assert.equal(false, ManifestParser.success());
+    assert.match(ManifestParser.logs()[0],
+	/^File isn't valid JSON: Double quotes are considered valid JSON, single quotes aren't. Please use double quotes./);
   });
 
   describe('name parsing', function() {


### PR DESCRIPTION
I've noticed people are often confused between single and double quotes in JSON. Let's add a specific error message instead of the cryptic `Unexpected token '`.
