### PR TITLE
Ignore *.pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+*.pyc


### PR DESCRIPTION
Since we use Python now, we may want to add *.pyc files to the `.gitignore` file.

R=@mounirlamouri
