### PR TITLE
Improved manifest logs results readability

### DIFF
--- a/static/manifest-parser.js
+++ b/static/manifest-parser.js
@@ -289,11 +289,11 @@ var ManifestParser = (function() {
     _logs.push('Parsed `orientation` property is: ' +
         _manifest.orientation);
     _logs.push('Parsed `icons` property is: ' +
-        _manifest.icons);
+        JSON.stringify(_manifest.icons, null, 4));
     _logs.push('Parsed `related_applications` property is: ' +
-        _manifest.related_applications);
+        JSON.stringify(_manifest.related_applications, null, 4));
     _logs.push('Parsed `prefer_related_applications` property is: ' +
-        _manifest.prefer_related_applications);
+        JSON.stringify(_manifest.prefer_related_applications, null, 4));
     _logs.push('Parsed `theme_color` property is: ' +
         _manifest.theme_color);
     _logs.push('Parsed `background_color` property is: ' +

--- a/static/styles.css
+++ b/static/styles.css
@@ -48,6 +48,10 @@
   margin: 48px 0 12px 0;
 }
 
+#log div {
+  white-space: pre-wrap;
+}
+
 .success {
   color: #4CAF50;
 }


### PR DESCRIPTION
Using `JSON.stringify` improves readability for Logs `Array` results.

![screenshot 2015-12-28 at 12 05 21 pm](https://cloud.githubusercontent.com/assets/634478/12017781/49ca7298-ad5b-11e5-8bec-260492111680.png)
