### PR TITLE
Added node_modules folder to skip_files

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -11,3 +11,10 @@ handlers:
   static_dir: static/
   secure: always
 
+skip_files:
+- ^(.*/)?#.*#$
+- ^(.*/)?.*~$
+- ^(.*/)?.*\.py[co]$
+- ^(.*/)?.*/RCS/.*$
+- ^(.*/)?\..*$
+- ^node_modules/.*$


### PR DESCRIPTION
In order to deploy the app successfully with Google Cloud SDK, we need to add the `skip_files` clause of app.yaml, as described here: https://cloud.google.com/appengine/docs/python/config/appconfig?hl=en#Python_app_yaml_Skipping_files

See https://code.google.com/p/google-cloud-sdk/issues/detail?id=392#c3

R=@mounirlamouri
