### PR TITLE
Re-added quotes in node_js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.12
-  - 4
-  - 5
+  - '0.10'
+  - '0.12'
+  - '4'
+  - '5'
 script:
   - npm test
   - npm run lint


### PR DESCRIPTION
Because Travis CI doesn't handle well `0.10` node_js version, let' re-add `'0.10'`.
R=@mounirlamouri
