### PR TITLE
Remove async for mdl library

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="material.light_blue-red.min.css">
     <link rel="stylesheet" href="styles.css">
 
-    <script src="material.min.js" async></script>
+    <script src="material.min.js"></script>
     <script src="ui.js" async></script>
     <script src="manifest-parser.js" async></script>
   </head>


### PR DESCRIPTION
This CL removes async attribute when loading mdl library as it sometimes fails to fire `mdl-componentupgraded` event.

R=@mounirlamouri
